### PR TITLE
feat: use inherited timezone

### DIFF
--- a/open-webui/tools/run_code.py
+++ b/open-webui/tools/run_code.py
@@ -487,6 +487,7 @@ class Sandbox:
                 "SHLVL=1",
                 "TERM=xterm",
                 "USER=user",
+                "TZ=" + time.tzname[0],
             ],
             "cwd": "/home/user",
             "capabilities": {


### PR DESCRIPTION
This lets the Sandbox inherit the Timezone from the open-webui container or machine. 

Future ideas: This could be a default and overridden with a valve.